### PR TITLE
Renamed `after` to `timeout`. Added timeout parameter to Push constructor

### DIFF
--- a/src/main/java/org/phoenixframework/channels/ITimeoutCallback.java
+++ b/src/main/java/org/phoenixframework/channels/ITimeoutCallback.java
@@ -1,0 +1,5 @@
+package org.phoenixframework.channels;
+
+public interface ITimeoutCallback {
+  void onTimeout();
+}

--- a/src/test/groovy/org/phoenixframework/channels/SocketSpec.groovy
+++ b/src/test/groovy/org/phoenixframework/channels/SocketSpec.groovy
@@ -5,7 +5,7 @@ import spock.util.concurrent.BlockingVariable
 
 class SocketSpec extends Specification {
 
-    def socket = new Socket("ws://localhost:4000/ws")
+    def socket = new Socket("ws://localhost:4000/socket/websocket")
 
     def socketOpenCallback = Mock(ISocketOpenCallback)
     def socketCloseCallback = Mock(ISocketCloseCallback)
@@ -27,7 +27,7 @@ class SocketSpec extends Specification {
         when:
         socket.connect()
         then:
-        1 * socketOpenCallback  .onOpen()
+        1 * socketOpenCallback.onOpen()
     }
 
     def "Channel subscribe"() {


### PR DESCRIPTION
This PR updates `after` function in Push to `timeout`. The Phoenix client API removed `after` and replaced it with just a receive with the `"timeout"` status. I also updated the function to take a ITimeoutCallback interface.

The Push constructor has been updated to take a timeout parameter. In Channel, I added an overload for the `push` function to allow for defining the timeout value. There is a default timeout set at 5000 milliseconds (Same as the Phoenix JavaScript client).

Please let me know what you think. I would be happy to change anything that should be changed.