### PR TITLE
Callbacks are garbage collecting in case of using WeakHashMaps

### DIFF
--- a/src/main/java/org/phoenixframework/channels/Socket.java
+++ b/src/main/java/org/phoenixframework/channels/Socket.java
@@ -44,10 +44,10 @@ public class Socket {
     private TimerTask reconnectTimerTask = null;
     private TimerTask heartbeatTimerTask = null;
 
-    private Set<ISocketOpenCallback> socketOpenCallbacks = Collections.newSetFromMap(new WeakHashMap<ISocketOpenCallback, Boolean>());
-    private Set<ISocketCloseCallback> socketCloseCallbacks = Collections.newSetFromMap(new WeakHashMap<ISocketCloseCallback, Boolean>());
-    private Set<IErrorCallback> errorCallbacks = Collections.newSetFromMap(new WeakHashMap<IErrorCallback, Boolean>());
-    private Set<IMessageCallback> messageCallbacks = Collections.newSetFromMap(new WeakHashMap<IMessageCallback, Boolean>());
+    private Set<ISocketOpenCallback> socketOpenCallbacks = Collections.newSetFromMap(new HashMap<ISocketOpenCallback, Boolean>());
+    private Set<ISocketCloseCallback> socketCloseCallbacks = Collections.newSetFromMap(new HashMap<ISocketCloseCallback, Boolean>());
+    private Set<IErrorCallback> errorCallbacks = Collections.newSetFromMap(new HashMap<IErrorCallback, Boolean>());
+    private Set<IMessageCallback> messageCallbacks = Collections.newSetFromMap(new HashMap<IMessageCallback, Boolean>());
 
     private int refNo = 1;
 


### PR DESCRIPTION
Using WeakHashMap leads to loosing callbacks, sometimes even before OnOpen callback starts.

For example, the following code doesn't work very often (not only once but very often):

```(android)
        try {
            socket = new Socket(BuildConfig.HOST);
            socket.onOpen(new ISocketOpenCallback() {
                @Override
                public void onOpen() {
                    Log.d(MainActivity.class.getName(), "Socket opened...");
                    try {
                        channel = socket.chan("test:chan", null);
                        channel.join()
                                .receive("ok", new IMessageCallback() {
                                    @Override
                                    public void onMessage(Envelope envelope) {
                                        Log.d(MainActivity.class.getName(), "join ok");
                                    }
                                });
                    } catch(IOException e) {
                        Log.d(MainActivity.class.getSimpleName(), "Channel join error: " + e.toString());
                    }
                }
            });
            socket.onClose(new ISocketCloseCallback() {
                @Override
                public void onClose() {
                    Log.d(MainActivity.class.getName(), "Socket closed...");
                }
            });
            socket.onError(new IErrorCallback() {
                @Override
                public void onError(String reason) {
                    Log.d(MainActivity.class.getName(), "Socket Error: " + reason);
                }
            });
            socket.connect();
        } catch (IOException e) {
            Log.d(MainActivity.class.getSimpleName(), "Socket connection error: " + e.toString());
        }
```
None of the callbacks run, no messages in logs, no channel joins.

In case of changing WeakHashMap to HashMap callbacks work every time.

Thanks to @alfredbaudisch and issue #20 .