### PR TITLE
Change scheduleRepeatingTask() to scheduleTask()

### DIFF
--- a/src/main/java/org/phoenixframework/channels/Channel.java
+++ b/src/main/java/org/phoenixframework/channels/Channel.java
@@ -265,7 +265,7 @@ public class Channel {
                 }
             }
         };
-        scheduleRepeatingTask(rejoinTimerTask, Socket.RECONNECT_INTERVAL_MS);
+        scheduleTask(rejoinTimerTask, Socket.RECONNECT_INTERVAL_MS);
     }
 
 


### PR DESCRIPTION
rejoinTimerTask runs rejoinUntilConnected() which checks for the current channel\socket state and either rejoin channel or schedule the next check. So the task must be set to start only once after each check.
Current behaviour leads to the memory allocation error and application crash in case of the network problems.