### PR TITLE
Fix TargetCompability of Java

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ if(project.hasProperty('signing.keyId'))
 group = 'org.phoenixframework.channels'
 version = '0.1.0'
 sourceCompatibility = '1.7'
-targetCompatibility = '1.6'
+targetCompatibility = '1.7'
 
 dependencies {
   compile fileTree(dir: 'libs', include: ['*.jar'])


### PR DESCRIPTION
This fixes the following error :  
```bash
:compileJava
javacTask: source release 1.7 requires target release 1.7
:compileJava FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':compileJava'.
> Compilation failed; see the compiler error output for details.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.

BUILD FAILED
```

If you found a better solution for this let me know. I hope it helps :)