### PR TITLE
Synchronize loop over channels.

### DIFF
--- a/src/main/java/org/phoenixframework/channels/Socket.java
+++ b/src/main/java/org/phoenixframework/channels/Socket.java
@@ -84,9 +84,11 @@ public class Socket {
                 if (payload.contentType() == WebSocket.TEXT) {
                     final Envelope envelope =
                         objectMapper.readValue(payload.byteStream(), Envelope.class);
-                    for (final Channel channel : channels) {
-                        if (channel.isMember(envelope.getTopic())) {
-                            channel.trigger(envelope.getEvent(), envelope);
+                    synchronized (channels) {
+                        for (final Channel channel : channels) {
+                            if (channel.isMember(envelope.getTopic())) {
+                                channel.trigger(envelope.getEvent(), envelope);
+                            }
                         }
                     }
 


### PR DESCRIPTION
The for loop in src/main/java/org/phoenixframework/channels/Socket.java could cause an ConcurrentModificationException in our project. The synchronized block should prevent that.

Extracted from https://github.com/eoinsha/JavaPhoenixChannels/pull/27