### PR TITLE
Fix ConcurrentModficationException issue

### DIFF
--- a/src/main/java/org/phoenixframework/channels/Socket.java
+++ b/src/main/java/org/phoenixframework/channels/Socket.java
@@ -6,14 +6,8 @@ import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Set;
-import java.util.Timer;
-import java.util.TimerTask;
+import java.util.*;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -92,6 +86,8 @@ public class Socket {
                 }
             } catch (IOException e) {
                 LOG.log(Level.SEVERE, "Failed to read message payload", e);
+            } catch (ConcurrentModificationException e) {
+                LOG.log(Level.SEVERE, "ConcurrentModificationException!", e);
             } finally {
                 payload.close();
             }
@@ -124,7 +120,7 @@ public class Socket {
 
     private static final int DEFAULT_HEARTBEAT_INTERVAL = 7000;
 
-    private final List<Channel> channels = new ArrayList<>();
+    private final List<Channel> channels = new CopyOnWriteArrayList<>();
 
     private String endpointUri = null;
 


### PR DESCRIPTION


## Steps taken

- Use CopyOnWriteArrayList
- Catch ConcurrentModificationException and show logs of said issue

## Issue #39 

Relevant to: https://github.com/eoinsha/JavaPhoenixChannels/issues/39

Repeatedly getting the following error:

`02-01 15:21:56.062 2703-3457/com.kayako.android.k5 E/AndroidRuntime: FATAL EXCEPTION: OkHttp Dispatcher
                                                                     Process: com.kayako.android.k5, PID: 2703
                                                                     java.util.ConcurrentModificationException
                                                                         at java.util.ArrayList$Itr.next(ArrayList.java:831)
                                                                         at org.phoenixframework.channels.Socket$PhoenixWSListener.onMessage(Socket.java:82)
                                                                         at okhttp3.internal.ws.RealWebSocket$1.onMessage(RealWebSocket.java:62)
                                                                         at okhttp3.internal.ws.WebSocketReader.readMessageFrame(WebSocketReader.java:242)
                                                                         at okhttp3.internal.ws.WebSocketReader.processNextFrame(WebSocketReader.java:108)
                                                                         at okhttp3.internal.ws.RealWebSocket.readMessage(RealWebSocket.java:97)
                                                                         at okhttp3.ws.WebSocketCall.createWebSocket(WebSocketCall.java:152)
                                                                         at okhttp3.ws.WebSocketCall.access$000(WebSocketCall.java:41)
                                                                         at okhttp3.ws.WebSocketCall$1.onResponse(WebSocketCall.java:97)
                                                                         at okhttp3.RealCall$AsyncCall.execute(RealCall.java:126)
                                                                         at okhttp3.internal.NamedRunnable.run(NamedRunnable.java:32)
                                                                         at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1133)
                                                                         at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:607)
                                                                         at java.lang.Thread.run(Thread.java:761)
`

