### PR TITLE
Adding explicit values for the JsonProperty annotation on Envelop

### DIFF
--- a/src/main/java/org/phoenixframework/channels/Envelope.java
+++ b/src/main/java/org/phoenixframework/channels/Envelope.java
@@ -5,16 +5,16 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 
 public class Envelope {
-    @JsonProperty
+    @JsonProperty(value = "topic")
     private String topic;
 
-    @JsonProperty
+    @JsonProperty(value = "event")
     private String event;
 
     @JsonProperty(value = "payload")
     private JsonNode payload;
 
-    @JsonProperty
+    @JsonProperty(value = "ref")
     private String ref;
 
     @SuppressWarnings("unused")


### PR DESCRIPTION
When using this library on an Android project with proguard, it requires a rule in order to avoid obfuscation of `Envelop`'s fields. Otherwise this kind of errors might appear:

```
Failed to read message payload
     com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException: 
     Unrecognized field “topic” (class o.xy), not marked as ignorable (4 known properties: “`”, “ˎ”, “ˏ”, “payload”])
```

Instead of forcing the user of this library to add an additional rule for this case, we can specify the json property names, so that jackson can bind the fields even if their names are obfuscated.